### PR TITLE
imageDir needs to exist for backup to work

### DIFF
--- a/app/src/main/java/dev/corruptedark/diditakemymeds/MainActivity.kt
+++ b/app/src/main/java/dev/corruptedark/diditakemymeds/MainActivity.kt
@@ -305,6 +305,13 @@ class MainActivity : AppCompatActivity() {
             openAddMedActivity()
         }
 
+        // imageDir needs to exist for backup to work
+        imageDir?.let {
+            if (!it.exists()) {
+                it.mkdir()
+            }
+        }
+
         val footerPadding = Space(this)
         footerPadding.minimumHeight = TypedValue.applyDimension(
             TypedValue.COMPLEX_UNIT_DIP,


### PR DESCRIPTION
if there are no proof images for medications, the backup routine fails
because it expects imageDir to exist.